### PR TITLE
Fix single option autocomplete

### DIFF
--- a/src/AutoCompleteTextField.js
+++ b/src/AutoCompleteTextField.js
@@ -382,7 +382,7 @@ class AutocompleteTextField extends React.Component {
       if (
         slug.matchLength >= minChars
         && (
-          slug.options.length > 1
+          slug.options.length >= 1
           || (
             slug.options.length === 1
             && slug.options[0].length !== slug.matchLength


### PR DESCRIPTION
In the actual repo, if there are any options with a single character, it somehow ignores that and does not show anything. This PR fixes this by ensuring that options with at least one character is used.

## Codesandbox link - with error and with fix
https://codesandbox.io/s/dazzling-morse-ybiwd7?file=/src/App.js
